### PR TITLE
Pdbe 3734 (msa access)

### DIFF
--- a/src/custom-pv-components/pdb-seq-conservation.js
+++ b/src/custom-pv-components/pdb-seq-conservation.js
@@ -22,19 +22,8 @@ class ProtvistaPdbSeqConservation extends ProtvistaPdbTrack {
     }
 
     set data(data) {
-        this._seqid = (this._accession && this._accession !== 'null') ? data[this._accession]['seqId'] : undefined;
         this._data = (this._accession && this._accession !== 'null') ? data[this._accession]['data'] : data;
-        this.add_download_link();
         this._createTrack();
-    }
-
-    add_download_link() {
-        if (this._seqid) {
-            const filelocation = "/nfs/msd/release/data/conserved_residues/all/sto";
-            const filename = filelocation + '/' + this._seqid + ".sto";
-        } else {
-            return false;
-        }
     }
 
     _createTrack() {
@@ -58,6 +47,8 @@ class ProtvistaPdbSeqConservation extends ProtvistaPdbTrack {
 
         this.seq_g = this.svg.append("g").attr("class", "sequence-features").attr("transform", "translate(0,-5)");
 
+        // Set the "property" view as default
+        this.filterData("property");
         this._createFeatures();
         this.refresh();
     }
@@ -178,7 +169,7 @@ class ProtvistaPdbSeqConservation extends ProtvistaPdbTrack {
                                 cancelable: true
                             })
                         );
-                    })
+                    });
 
 
                 // add tooltip

--- a/src/helpers/layout.js
+++ b/src/helpers/layout.js
@@ -623,6 +623,17 @@ class LayoutHelper {
         }));
     }
 
+    getMSADownloadUrl() {
+        let baseUrl = "https://www.ebi.ac.uk/pdbe/static/alignments/";
+        if (this.ctx._accession) {
+            return baseUrl + this.ctx._accession + ".sto.gz";
+        } else if (this.ctx._entryId) {
+            return baseUrl + this.ctx._entryId + ".sto.gz";
+        } else {
+            return "";
+        }
+    }
+
     addEventSubscription() {
         document.addEventListener("PDB.topologyViewer.click", e => {
             this.handleExtEvents(e);

--- a/src/section-templates/seq-conservation.js
+++ b/src/section-templates/seq-conservation.js
@@ -44,15 +44,18 @@ function PDBePvScSection(ctx) {
                                 </div>
                             </div>
 
+                            <!-- Note: Display is set to none until we expose MSA files per PDB entity -->
                             <div @mouseover=${e => {
                                 e.stopPropagation();
                                 ctx.layoutHelper.showLabelTooltip(e)
                                 }} @mouseout=${e => {
                                 e.stopPropagation();
                                 ctx.layoutHelper.hideLabelTooltip()
-                            }}>
+                            }}
+                            style = "${ctx._entryId ? "display: none" : ""}"
+                            >
                                 <a class="button" style="padding: 2px 4px 2px 4px; background-color: #ececec; border: solid 1px dimgrey; border-radius: 3px"
-                                    href="https://wwwdev.ebi.ac.uk/pdbe/static/alignments/${ctx._accession}.sto.gz">
+                                    href="${ctx.layoutHelper.getMSADownloadUrl()}">
                                     Download MSA <i class="icon icon-functional" data-icon="="></i>
                                 </a>
                                 <span class="labelTooltipContent" style="display:none;">

--- a/src/section-templates/seq-conservation.js
+++ b/src/section-templates/seq-conservation.js
@@ -1,7 +1,7 @@
-const { html } = require("lit-html");
+const {html} = require("lit-html");
 
 function PDBePvScSection(ctx) {
-    return html `<div class="protvistaRow pvConsHistoRow" style="display:none">
+    return html`<div class="protvistaRow pvConsHistoRow" style="display:none">
                     
                     <div class="protvistaCol1 category-label" @click=${e => ctx.layoutHelper.showConservationPlot()} style="background-color:rgb(128,128,128); borderBottom:1px solid lightgrey">Sequence conservation</div>
 
@@ -12,19 +12,52 @@ function PDBePvScSection(ctx) {
                 <div class="pvConservationPlotRow" style="display:none">
                     <div class="protvistaRow">
                         <div class="protvistaCol1 track-label" style="background-color:rgb(211,211,211); borderBottom:1px solid lightgrey">
-                            <div style="height:30px;"><b>Amino acid probabilities</b></div>
+                            <div style="height:30px;">
+                                <b>Amino acid probabilities</b>
+                                <span style="float: right" @mouseover=${e => {
+                                    e.stopPropagation();
+                                    ctx.layoutHelper.showLabelTooltip(e)
+                                    }} @mouseout=${e => {
+                                    e.stopPropagation();
+                                    ctx.layoutHelper.hideLabelTooltip()
+                                }}>
+                                    <a href="https://github.com/PDBe-KB/pdbe-kb-manual/wiki/Sequence-conservation-scores" target="_blank"
+                                    style="border-bottom: none">
+                                        <i class="icon icon-generic" data-icon="?"></i>
+                                    </a>
+                                    <span class="labelTooltipContent" style="display:none;">
+                                        The amino acid probabilities are calculated using HMM profiles based on multiple sequence alignments. Click to see more details...
+                                    </span>
+                                </span>
+                            </div>
                             <div class="control" style="height:90px;">
                                 <p>Data displayed by</p>
                                 <div>
                                     <label class="legendText">
-                                        <input type="radio" class="sc_radio" name="sc_display_radio" value="probability" checked @change=${e => ctx.layoutHelper.filterSc('probability')}>Probability
+                                        <input type="radio" class="sc_radio" name="sc_display_radio" value="property" checked @change=${e => ctx.layoutHelper.filterSc('property')}>Property
                                     </label>
                                 </div>
                                 <div>
                                     <label class="legendText">
-                                        <input type="radio" class="sc_radio" name="sc_display_radio" value="property" @change=${e => ctx.layoutHelper.filterSc('property')}>Property
+                                        <input type="radio" class="sc_radio" name="sc_display_radio" value="probability" @change=${e => ctx.layoutHelper.filterSc('probability')}>Probability
                                     </label>
                                 </div>
+                            </div>
+
+                            <div @mouseover=${e => {
+                                e.stopPropagation();
+                                ctx.layoutHelper.showLabelTooltip(e)
+                                }} @mouseout=${e => {
+                                e.stopPropagation();
+                                ctx.layoutHelper.hideLabelTooltip()
+                            }}>
+                                <a class="button" style="padding: 2px 4px 2px 4px; background-color: #ececec; border: solid 1px dimgrey; border-radius: 3px"
+                                    href="https://wwwdev.ebi.ac.uk/pdbe/static/alignments/${ctx._accession}.sto.gz">
+                                    Download MSA <i class="icon icon-functional" data-icon="="></i>
+                                </a>
+                                <span class="labelTooltipContent" style="display:none;">
+                                    Click to download the multiple sequence alignment (MSA) file
+                                </span>
                             </div>
 
                             <div class="legend" style="height:200px;">
@@ -74,7 +107,7 @@ function PDBePvScSection(ctx) {
                         </div>
                     </div>
                 </div>`
-        
+
 }
 
 export default PDBePvScSection;


### PR DESCRIPTION
Hi Mandar, this is a small change to:
* allow the download of MSA files for UniProt entries
* hide this option for PDB entries, until the data becomes available
* display tooltip with information on the sequence conservation
* display the sequence logo ordered by probabilities